### PR TITLE
Arbitrary NSData failed to be decoded properly

### DIFF
--- a/Example/Tests/DSCborDecodingTests.m
+++ b/Example/Tests/DSCborDecodingTests.m
@@ -95,4 +95,31 @@
     XCTAssertNil(error);
 }
 
+- (void)testEncodingAndDecodingRandomData {
+    int numBytes = 64;
+    NSMutableData *data = [NSMutableData dataWithCapacity:numBytes];
+    for(unsigned int i = 0; i < numBytes/4; i++) {
+        uint32_t randomBits = arc4random();
+        [data appendBytes:(void*)&randomBits length:4];
+    }
+
+    NSDictionary *d = @{ @"d" :
+                             @[
+                                @"str",
+                                @42,
+                                @{
+                                   @"data" : data,
+                                },
+                             ],
+    };
+
+    NSData *encoded = [d ds_cborEncodedObject];
+    XCTAssertNotNil(encoded);
+
+    NSError *error = nil;
+    id decoded = [encoded ds_decodeCborError:&error];
+    XCTAssertEqualObjects(decoded, d);
+    XCTAssertNil(error);
+}
+
 @end

--- a/TinyCborObjc/cbortojson_nsstring.m
+++ b/TinyCborObjc/cbortojson_nsstring.m
@@ -524,7 +524,7 @@ static CborError value_to_json(NSMutableString *out, CborValue *it, int flags, C
     case CborTextStringType: {
         char *str;
         if (type == CborByteStringType) {
-            err = dump_bytestring_base64url(&str, it);
+            err = dump_bytestring_base64(&str, it);
             status->flags = TypeWasNotNative;
         } else {
             size_t n = 0;


### PR DESCRIPTION
Problem: Arbitrary NSData would seemingly be encoded properly but would then fail to be decoded properly, leaving an NSString in its place with the `DSCborBase64DataMarker` prepended.

Solution: Use `dump_bytestring_base64` as opposed to `dump_bytestring_base64url`.