### PR TITLE
Fix buffer overrun

### DIFF
--- a/Example/Tests/DSCborDecodingTests.m
+++ b/Example/Tests/DSCborDecodingTests.m
@@ -60,6 +60,18 @@
     XCTAssertNil(error);
 }
 
+- (void)testEncodingAndDecodingLargeString {
+    NSString *str = [@"" stringByPaddingToLength:50000 withString: @"a" startingAtIndex:0];
+    NSData *encoded = [str ds_cborEncodedObject];
+    XCTAssertNotNil(encoded);
+    
+    NSError *error = nil;
+    id decoded = [encoded ds_decodeCborError:&error];
+    XCTAssertEqual(((NSString *)decoded).length, 50000);
+    XCTAssertEqualObjects(decoded, str);
+    XCTAssertNil(error);
+}
+
 - (void)testDecodingData {
     NSData *encoded = DATABYTES(0xa1, 0x64, 0x64, 0x61, 0x74, 0x61, 0x43, 0x61, 0x62, 0x63);
     NSString *dataString = @"abc";

--- a/Example/Tests/DSCborDecodingTests.m
+++ b/Example/Tests/DSCborDecodingTests.m
@@ -72,6 +72,33 @@
     XCTAssertNil(error);
 }
 
+- (void)testEncodingAndDecodingLargeObject {
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity: 26];
+
+    for (NSUInteger i = 0; i < 26; i++) {
+        NSString *character = [[NSString alloc] initWithFormat:@"%c", (int)('a' + i)];
+        NSString *str = [@"" stringByPaddingToLength:50000 withString: character startingAtIndex:0];
+        dict[character] = str;
+    }
+
+    NSData *encoded = [dict ds_cborEncodedObject];
+    XCTAssertNotNil(encoded);
+
+    NSError *error = nil;
+    NSDictionary *decoded = (NSDictionary *)[encoded ds_decodeCborError:&error];
+    XCTAssertNil(error);
+
+    NSString *aString = (NSString *)decoded[@"a"];
+    NSCharacterSet *notA = [[NSCharacterSet characterSetWithCharactersInString: @"a"] invertedSet];
+    XCTAssertEqual([aString rangeOfCharacterFromSet:notA].location, NSNotFound);
+    XCTAssertEqual(aString.length, 50000);
+
+    NSString *zString = (NSString *)decoded[@"z"];
+    NSCharacterSet *notZ = [[NSCharacterSet characterSetWithCharactersInString: @"z"] invertedSet];
+    XCTAssertEqual([zString rangeOfCharacterFromSet:notZ].location, NSNotFound);
+    XCTAssertEqual(zString.length, 50000);
+}
+
 - (void)testDecodingData {
     NSData *encoded = DATABYTES(0xa1, 0x64, 0x64, 0x61, 0x74, 0x61, 0x43, 0x61, 0x62, 0x63);
     NSString *dataString = @"abc";

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -217,6 +217,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
                                 encodingBlock:(CborError (^)(void))encodingBlock {
     CborError err = CborNoError;
     CborEncoder tmpencoder = *encoder;
+    ptrdiff_t tempOffset = tmpencoder.data.ptr - *buffer;
     do {
         if (err == CborErrorOutOfMemory) {
             bufferSize += DSCborEncodingBufferChunkSize; // Why not the following? `(1 + encoder->data.bytes_needed / DSCborEncodingBufferChunkSize) * DSCborEncodingBufferChunkSize;`
@@ -227,7 +228,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 
             // restore state
             *encoder = tmpencoder;
-            encoder->data.ptr = newbuffer + (tmpencoder.data.ptr - *buffer); // `newbuffer + tmpOffset;` (where `tempOffset = *encoder.data.ptr - *buffer;` is set outside the loop)
+            encoder->data.ptr = newbuffer + tempOffset;
             encoder->end = newbuffer + bufferSize;
             *buffer = newbuffer;
         }

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -53,7 +53,9 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 
     CborEncoder encoder;
     cbor_encoder_init(&encoder, buffer, bufferSize, 0);
-    CborError err = [self ds_encodeObject:self intoBuffer:&buffer bufferSize:bufferSize encoder:&encoder];
+    CborError err = [self ds_encodeObject:self intoBuffer:&buffer
+                               bufferSize:&bufferSize
+                                  encoder:&encoder];
 
     NSData *data = nil;
     if (err == CborNoError) {
@@ -77,18 +79,24 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 
 - (CborError)ds_encodeObject:(id)object
                   intoBuffer:(uint8_t **)buffer
-                  bufferSize:(size_t)bufferSize
+                  bufferSize:(size_t *)bufferSize
                      encoder:(CborEncoder *)encoder {
     if ([object isKindOfClass:NSString.class]) {
         NSString *stringObject = (NSString *)object;
-        return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+        return [self ds_performSafeEncodingIntoBuffer:buffer
+                                           bufferSize:bufferSize
+                                              encoder:encoder
+                                        encodingBlock:^CborError {
             return cbor_encode_text_stringz(encoder, stringObject.UTF8String);
         }];
     }
     else if ([object isKindOfClass:NSNumber.class]) {
         NSNumber *numberObject = (NSNumber *)object;
         if ([numberObject isKindOfClass:@YES.class]) {
-            return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+            return [self ds_performSafeEncodingIntoBuffer:buffer
+                                               bufferSize:bufferSize
+                                                  encoder:encoder
+                                            encodingBlock:^CborError {
                 return cbor_encode_boolean(encoder, numberObject.boolValue);
             }];
         }
@@ -97,13 +105,19 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             switch (numberType) {
                 case kCFNumberSInt8Type:
                 case kCFNumberCharType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.charValue);
                     }];
                 }
                 case kCFNumberSInt16Type:
                 case kCFNumberShortType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.shortValue);
                     }];
                 }
@@ -112,26 +126,38 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
                 case kCFNumberLongType:
                 case kCFNumberNSIntegerType:
                 case kCFNumberCFIndexType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.integerValue);
                     }];
                 }
                 case kCFNumberSInt64Type:
                 case kCFNumberLongLongType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.longLongValue);
                     }];
                 }
                 case kCFNumberFloat32Type:
                 case kCFNumberFloatType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_float(encoder, numberObject.floatValue);
                     }];
                 }
                 case kCFNumberFloat64Type:
                 case kCFNumberDoubleType:
                 case kCFNumberCGFloatType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+                    return [self ds_performSafeEncodingIntoBuffer:buffer
+                                                       bufferSize:bufferSize
+                                                          encoder:encoder
+                                                    encodingBlock:^CborError {
                         return cbor_encode_double(encoder, numberObject.doubleValue);
                     }];
                 }
@@ -139,7 +165,10 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
         }
     }
     else if ([object isKindOfClass:NSNull.class]) {
-        return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+        return [self ds_performSafeEncodingIntoBuffer:buffer
+                                           bufferSize:bufferSize
+                                              encoder:encoder
+                                        encodingBlock:^CborError {
             return cbor_encode_null(encoder);
         }];
     }
@@ -153,7 +182,10 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             return err;
         }
         for (id item in arrayObject) {
-            err = [self ds_encodeObject:item intoBuffer:buffer bufferSize:bufferSize encoder:&container];
+            err = [self ds_encodeObject:item
+                             intoBuffer:buffer
+                             bufferSize:bufferSize
+                                encoder:&container];
             if (err != CborNoError) {
                 return err;
             }
@@ -187,13 +219,19 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             return result;
         }];
         for (id key in sortedKeys) {
-            err = [self ds_encodeObject:key intoBuffer:buffer bufferSize:bufferSize encoder:&container];
+            err = [self ds_encodeObject:key
+                             intoBuffer:buffer
+                             bufferSize:bufferSize
+                                encoder:&container];
             if (err != CborNoError) {
                 return err;
             }
 
             id value = dictionaryObject[key];
-            err = [self ds_encodeObject:value intoBuffer:buffer bufferSize:bufferSize encoder:&container];
+            err = [self ds_encodeObject:value
+                             intoBuffer:buffer
+                             bufferSize:bufferSize
+                                encoder:&container];
             if (err != CborNoError) {
                 return err;
             }
@@ -202,7 +240,10 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
     }
     else if ([object isKindOfClass:NSData.class]) {
         NSData *dataObject = (NSData *)object;
-        return [self ds_performSafeEncodingIntoBuffer:buffer bufferSize:bufferSize encoder:encoder encodingBlock:^CborError {
+        return [self ds_performSafeEncodingIntoBuffer:buffer
+                                           bufferSize:bufferSize
+                                              encoder:encoder
+                                        encodingBlock:^CborError {
             return cbor_encode_byte_string(encoder, dataObject.bytes, dataObject.length);
         }];
     }
@@ -212,7 +253,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 }
 
 - (CborError)ds_performSafeEncodingIntoBuffer:(uint8_t **)buffer
-                                   bufferSize:(size_t)bufferSize
+                                   bufferSize:(size_t *)bufferSize
                                       encoder:(CborEncoder *)encoder
                                 encodingBlock:(CborError (^)(void))encodingBlock {
     CborError err = CborNoError;
@@ -229,9 +270,9 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             // to succeed on the next attempt for the current key which
             // caused the OOM situation. Note that there may still be
             // subsequent keys which trigger another OOM situation.
-            bufferSize += (1 + encoder->data.bytes_needed / DSCborEncodingBufferChunkSize)
+            *bufferSize += (1 + encoder->data.bytes_needed / DSCborEncodingBufferChunkSize)
                 * DSCborEncodingBufferChunkSize;
-            uint8_t *newbuffer = realloc(*buffer, bufferSize);
+            uint8_t *newbuffer = realloc(*buffer, *bufferSize);
             if (newbuffer == NULL) {
                 return CborErrorOutOfMemory;
             }
@@ -239,7 +280,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             // restore state
             *encoder = savedEncoder;
             encoder->data.ptr = newbuffer + savedOffset;
-            encoder->end = newbuffer + bufferSize;
+            encoder->end = newbuffer + *bufferSize;
             *buffer = newbuffer;
         }
 

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -105,20 +105,20 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
                      encoder:(CborEncoder *)encoder {
     if ([object isKindOfClass:NSString.class]) {
         NSString *stringObject = (NSString *)object;
-        return [self ds_performSafeEncodingIntoBuffer:buffer
-                                           bufferSize:bufferSize
-                                              encoder:encoder
-                                        encodingBlock:^CborError {
+        return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                               bufferSize:bufferSize
+                                                  encoder:encoder
+                                            encodingBlock:^CborError {
             return cbor_encode_text_stringz(encoder, stringObject.UTF8String);
         }];
     }
     else if ([object isKindOfClass:NSNumber.class]) {
         NSNumber *numberObject = (NSNumber *)object;
         if ([numberObject isKindOfClass:@YES.class]) {
-            return [self ds_performSafeEncodingIntoBuffer:buffer
-                                               bufferSize:bufferSize
-                                                  encoder:encoder
-                                            encodingBlock:^CborError {
+            return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                   bufferSize:bufferSize
+                                                      encoder:encoder
+                                                encodingBlock:^CborError {
                 return cbor_encode_boolean(encoder, numberObject.boolValue);
             }];
         }
@@ -127,19 +127,19 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
             switch (numberType) {
                 case kCFNumberSInt8Type:
                 case kCFNumberCharType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.charValue);
                     }];
                 }
                 case kCFNumberSInt16Type:
                 case kCFNumberShortType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.shortValue);
                     }];
                 }
@@ -148,38 +148,38 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
                 case kCFNumberLongType:
                 case kCFNumberNSIntegerType:
                 case kCFNumberCFIndexType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.integerValue);
                     }];
                 }
                 case kCFNumberSInt64Type:
                 case kCFNumberLongLongType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_int(encoder, numberObject.longLongValue);
                     }];
                 }
                 case kCFNumberFloat32Type:
                 case kCFNumberFloatType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_float(encoder, numberObject.floatValue);
                     }];
                 }
                 case kCFNumberFloat64Type:
                 case kCFNumberDoubleType:
                 case kCFNumberCGFloatType: {
-                    return [self ds_performSafeEncodingIntoBuffer:buffer
-                                                       bufferSize:bufferSize
-                                                          encoder:encoder
-                                                    encodingBlock:^CborError {
+                    return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                                           bufferSize:bufferSize
+                                                              encoder:encoder
+                                                        encodingBlock:^CborError {
                         return cbor_encode_double(encoder, numberObject.doubleValue);
                     }];
                 }
@@ -187,10 +187,10 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
         }
     }
     else if ([object isKindOfClass:NSNull.class]) {
-        return [self ds_performSafeEncodingIntoBuffer:buffer
-                                           bufferSize:bufferSize
-                                              encoder:encoder
-                                        encodingBlock:^CborError {
+        return [self ds_encodeByExpandingBufferIfRequired:buffer
+                                               bufferSize:bufferSize
+                                                  encoder:encoder
+                                            encodingBlock:^CborError {
             return cbor_encode_null(encoder);
         }];
     }
@@ -262,7 +262,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
     }
     else if ([object isKindOfClass:NSData.class]) {
         NSData *dataObject = (NSData *)object;
-        return [self ds_performSafeEncodingIntoBuffer:buffer
+        return [self ds_encodeByExpandingBufferIfRequired:buffer
                                            bufferSize:bufferSize
                                               encoder:encoder
                                         encodingBlock:^CborError {
@@ -296,10 +296,10 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
  is returned, then the system is out of memory and growing the buffer
  further will not be successful.
  */
-- (CborError)ds_performSafeEncodingIntoBuffer:(uint8_t **)buffer
-                                   bufferSize:(size_t *)bufferSize
-                                      encoder:(CborEncoder *)encoder
-                                encodingBlock:(CborError (^)(void))encodingBlock {
+- (CborError)ds_encodeByExpandingBufferIfRequired:(uint8_t **)buffer
+                                       bufferSize:(size_t *)bufferSize
+                                          encoder:(CborEncoder *)encoder
+                                    encodingBlock:(CborError (^)(void))encodingBlock {
     CborError err = CborNoError;
 
     // Save the state of the encoder and its offset in the buffer so that

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -220,8 +220,8 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
     // Save the state of the encoder and its offset in the buffer so that
     // in the event of an out-of-memory situation we can grow the buffer,
     // reset our encoder state and try again with the larger buffer.
-    CborEncoder savedEncoder = *encoder;
-    ptrdiff_t savedOffset = savedEncoder.data.ptr - *buffer;
+    const CborEncoder savedEncoder = *encoder;
+    const ptrdiff_t savedOffset = savedEncoder.data.ptr - *buffer;
 
     do {
         if (err == CborErrorOutOfMemory) {

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -77,6 +77,28 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 
 #pragma mark Private
 
+/**
+ Recursively encodes an object into a given buffer. If required, the
+ buffer will be expanded.
+
+ @param object The object which will be encoded. It must be one of
+ `NSDictionary`, `NSArray`,`NSString`, `NSNumber`, `NSNull`, `NSData`
+ or their mutable variants. If `object` is an `NSDictionary` or
+ `NSArray` then this function will recurse, encoding each of their entries.
+ @param buffer A pointer to the buffer into which the encoded form
+ of `object` should be written. The buffer may be reallocated and
+ therefore must exist on the heap. Do not pass a stack buffer. If it
+ was neccessary to grow the buffer during the encoding process, the
+ original `buffer` will be `free()`d and `buffer` will be overritten with
+ a pointer to the enlarged buffer.
+ @param bufferSize The number of bytes in `buffer`. If it was neccessary
+ to grow the buffer during the encoding process, then the enlarged `buffer`
+ size will be written to `bufferSize`.
+ @param encoder A pointer to to the tinycbor encoder which will perform
+ the encoding.
+ @returns Returns the result of the encoding operation (which will be
+ `CborNoError` if encoding was successful.
+ */
 - (CborError)ds_encodeObject:(id)object
                   intoBuffer:(uint8_t **)buffer
                   bufferSize:(size_t *)bufferSize
@@ -252,6 +274,28 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
     }
 }
 
+/**
+ Execute an encoding command within a block, repeatedly expanding the
+ buffer and retrying if the initial buffer proved too small.
+
+ @param buffer A pointer to the buffer into which the encoded form
+ of `object` should be written. The buffer may be reallocated and
+ therefore must exist on the heap. Do not pass a stack buffer. If it
+ was neccessary to grow the buffer during the encoding process, the
+ original `buffer` will be `free()`d and `buffer` will be overritten with
+ a pointer to the enlarged buffer.
+ @param bufferSize The number of bytes in `buffer`. If it was neccessary
+ to grow the buffer during the encoding process, then the enlarged `buffer`
+ size will be written to `bufferSize`.
+ @param encoder A pointer to to the tinycbor encoder which will perform
+ the encoding.
+ @param encodingBlock A block to be executed, typically containing a single
+ tinycbor encoding command.
+ @returns Returns the result of the encoding operation (which will be
+ `CborNoError` if encoding was successful. Note that if `CborErrorOutOfMemory`
+ is returned, then the system is out of memory and growing the buffer
+ further will not be successful.
+ */
 - (CborError)ds_performSafeEncodingIntoBuffer:(uint8_t **)buffer
                                    bufferSize:(size_t *)bufferSize
                                       encoder:(CborEncoder *)encoder

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -245,7 +245,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
 
         err = encodingBlock();
 
-    } while (err == CborErrorOutOfMemory); // WARNING: crude. Requires many reallocs and begins processing from new. Should estimate size first.
+    } while (err == CborErrorOutOfMemory);
 
     return err;
 }

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -233,7 +233,7 @@ static size_t const DSCborEncodingBufferChunkSize = 1024;
                 * DSCborEncodingBufferChunkSize;
             uint8_t *newbuffer = realloc(*buffer, bufferSize);
             if (newbuffer == NULL) {
-                return err; // WARNING: Would cause an infinite loop if this was ever triggered
+                return CborErrorOutOfMemory;
             }
 
             // restore state


### PR DESCRIPTION
Closes https://github.com/dashevo/TinyCborObjc/issues/17

---

# Problem

A buffer overflow occurs when encoding large items.

Specifically, the overflow will occur when encoding any object whose encoded size is greater than 2x the default allocation chunk used within the library (`DSCborEncodingBufferChunkSize` or 1024 bytes).

```objective-c
NSString *str = [@"" stringByPaddingToLength:50000 withString: @"a" startingAtIndex:0];
NSData *encoded = [str ds_cborEncodedObject];
```

# Analysis

The issue stems from the buffer reallocation logic in the following code.

```objective-c
- (CborError)ds_performSafeEncodingIntoBuffer:(uint8_t **)buffer
                                   bufferSize:(size_t)bufferSize
                                      encoder:(CborEncoder *)encoder
                                encodingBlock:(CborError (^)(void))encodingBlock {
    CborError err = CborNoError;
    CborEncoder tmpencoder = *encoder;
    do {
        if (err == CborErrorOutOfMemory) {
            bufferSize += DSCborEncodingBufferChunkSize;
            uint8_t *newbuffer = realloc(*buffer, bufferSize);
            if (newbuffer == NULL) {
                return err;
            }

            // restore state
            *encoder = tmpencoder;
            encoder->data.ptr = newbuffer + (tmpencoder.data.ptr - *buffer);
            encoder->end = newbuffer + bufferSize;
            *buffer = newbuffer;
        }

        err = encodingBlock();

    } while (err == CborErrorOutOfMemory);

    return err;
}
```

Specifically, the following statement:

```objective-c
encoder->data.ptr = newbuffer + (tmpencoder.data.ptr - *buffer);
``` 

The intention of this line is to `realloc` a larger buffer and then change the encoder's `pointer` from an offset X in the old buffer to the corresponding offset X in the newly `realloc`ed buffer. This would allow the encoder to continue encoding from the same point in a larger buffer, leaving the the prior encoded objects in the buffer untouched.

The `encoder->data.ptr = newbuffer + encoder->data.ptr - *buffer` statement results in junk after **two or more `realloc`s**. After two `realloc`s  the two operands are pointers into two **completely different, disjoint buffers** and no longer pointers to different locations in the same contiguous buffer. The pointer arithmetic is nonsensical when applied to operands that aren't part of the same contiguous buffer.

# Solution

We must store the buffer offset outside the loop instead of calculating it within the loop (by which point the buffers involved in the calculation have since changed). This was already being done to store a copy of the encoder on the stack as value type — so we merely expand this logic to include the buffer offset.

# Addendum

For the curious — I've reproduced here a set of lldb print statements which show the memory state during a run. The results of the incorrect statement are shown on the very last line.

```gdb
# Given the task of encoding: @{ "t" : "aa.......................x10000" }

# Status of temp encoder before encoding large string

    (lldb) p/a tmpencoder.end           = 0x000061900000fe80
    (lldb) p/a tmpencoder.data.ptr      = 0x000061900000fa83

    tmpencoder.end - tmpencoder.data.ptr = 0x3FD = 1021 = 3 bytes used
    # Explanation: Before beginning to encode the large field, we'd used 3 bytes
    # of our 1024 buffer to encode the top-level map and "t" key (1024 - 3 = 1021).


# State before first realloc:

    (lldb) p/a *buffer                  = 0x000061900000fa80
    (lldb) p/a encoder->data.ptr        = 0x000061900000fa86

    encoder->data.ptr - *buffer         = 0x6 = 6 bytes used
    # Explanation: We had used an additional 3 bytes attempting to encode
    # the string. The 3 bytes stem from the string marker plus two bytes for
    # its length. The encoding then ran out of memory when attempting to
    # encode the string bytes.


# First realloc
newbuffer = realloc(*buffer, 2048);

    (lldb) p/a newbuffer                = 0x000061d000173e80
    (lldb) p/a encoder->end             = 0x000061d000174680
    (lldb) p/a encoder->data.ptr        = 0x000061d000173e83
    # *buffer = newbuffer;

    encoder->data.ptr - *buffer         = 0x3 = 3 bytes used
    # Explanation: we correctly reset back to our state prior to encoding
    # the large string (which includes dropping the 3 bytes for the large
    # string marker).


# Second realloc
newbuffer = realloc(*buffer, 3072);

    (lldb) p/a newbuffer                = 0x000061f000021480
    (lldb) p/a encoder->encoder         = 0x000061f000022080
    (lldb) p/a encoder->data.ptr        = 0x000061afffebd08
    # *buffer = newbuffer;

    encoder->data.ptr - *buffer         = 0xFFFFA42AFFFCA888 = 18446643103323170952 bytes used
    # Explanation: at this point we just attempted pointer arithmetic on two
    # pointers from disjoint buffers. Our encoder's data pointer will be set to 
    # junk in the following statement:
    # `encoder->data.ptr = newbuffer + (tmpencoder.data.ptr - *buffer);`
```